### PR TITLE
Automated deploys via workflows

### DIFF
--- a/.github/workflows/development.yml
+++ b/.github/workflows/development.yml
@@ -1,7 +1,7 @@
-name: Deploy dmX beta to GitHub Pages
+name: Release version of dmX in GitHub Pages
 on:
     push:
-        branches: [beta]
+        branches: [release]
 
 permissions:
     contents: write
@@ -9,12 +9,14 @@ jobs:
     build-and-deploy:
         runs-on: ubuntu-latest
         steps:
-            - name: Checkout 🛎️
+            - name: Checkout
               uses: actions/checkout@v3
 
-            - name: Deploy 🚀
+            - name: Deploy
               uses: JamesIves/github-pages-deploy-action@v4
               with:
                   folder: .
-                  clean-exclude: pr-preview/
-                  target-folder: beta/
+                  clean-exclude: |
+                      pr-preview/
+                      main/
+                  target-folder: release/

--- a/.github/workflows/development.yml
+++ b/.github/workflows/development.yml
@@ -1,7 +1,7 @@
-name: Deploy dmX to GitHub Pages
+name: Deploy dmX beta to GitHub Pages
 on:
     push:
-        branches: [main]
+        branches: [beta]
 
 permissions:
     contents: write
@@ -16,6 +16,5 @@ jobs:
               uses: JamesIves/github-pages-deploy-action@v4
               with:
                   folder: .
-                  clean-exclude: |
-                      pr-preview/
-                      beta/
+                  clean-exclude: pr-preview/
+                  target-folder: beta/

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -13,8 +13,16 @@ jobs:
         steps:
             - uses: actions/checkout@v3
             - uses: rossjrw/pr-preview-action@v1
+              if: contains(['opened', 'reopened', 'synchronize'], ${{ github.event.action }})
               with:
                   source-dir: .
                   preview-branch: gh-pages
                   umbrella-dir: pr-preview
                   action: auto
+            - uses: rossjrw/pr-preview-action@v1
+              if: github.event.action == 'closed' && !github.event.pull_request.merged
+              with:
+                  source-dir: .
+                  preview-branch: gh-pages
+                  umbrella-dir: pr-preview
+                  action: remove

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -1,0 +1,20 @@
+name: Deploy PR previews to GitHub Pages
+concurrency: preview-${{ github.ref }}
+on:
+    pull_request:
+        types:
+            - opened
+            - reopened
+            - synchronize
+            - closed
+jobs:
+    deploy-preview:
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/checkout@v3
+            - uses: rossjrw/pr-preview-action@v1
+              with:
+                  source-dir: .
+                  preview-branch: gh-pages
+                  umbrella-dir: pr-preview
+                  action: auto

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -7,6 +7,8 @@ on:
             - reopened
             - synchronize
             - closed
+permissions:
+    contents: write
 jobs:
     deploy-preview:
         runs-on: ubuntu-latest

--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -1,0 +1,43 @@
+# Simple workflow for deploying static content to GitHub Pages
+name: Deploy static content to Pages
+
+on:
+    # Runs on pushes targeting the default branch
+    push:
+        branches: ["main"]
+
+    # Allows you to run this workflow manually from the Actions tab
+    workflow_dispatch:
+
+# Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
+permissions:
+    contents: read
+    pages: write
+    id-token: write
+
+# Allow only one concurrent deployment, skipping runs queued between the run in-progress and latest queued.
+# However, do NOT cancel in-progress runs as we want to allow these production deployments to complete.
+concurrency:
+    group: "pages"
+    cancel-in-progress: false
+
+jobs:
+    # Single deploy job since we're just deploying
+    deploy:
+        environment:
+            name: github-pages
+            url: ${{ steps.deployment.outputs.page_url }}
+        runs-on: ubuntu-latest
+        steps:
+            - name: Checkout
+              uses: actions/checkout@v4
+            - name: Setup Pages
+              uses: actions/configure-pages@v5
+            - name: Upload artifact
+              uses: actions/upload-pages-artifact@v3
+              with:
+                  # Upload entire repository
+                  path: "."
+            - name: Deploy to GitHub Pages
+              id: deployment
+              uses: actions/deploy-pages@v4

--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -9,13 +9,14 @@ jobs:
     build-and-deploy:
         runs-on: ubuntu-latest
         steps:
-            - name: Checkout 🛎️
+            - name: Checkout
               uses: actions/checkout@v3
 
-            - name: Deploy 🚀
+            - name: Deploy
               uses: JamesIves/github-pages-deploy-action@v4
               with:
                   folder: .
                   clean-exclude: |
                       pr-preview/
                       beta/
+                  target-folder: main/

--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -20,3 +20,4 @@ jobs:
                       pr-preview/
                       beta/
                   target-folder: main/
+                  force: false


### PR DESCRIPTION
BEGINRELEASENOTES
- This PR is related to #14.
- Here I've added 3 possible workflows that can be used to deploy dmX.
- All deploys will be hosted with GitHub Pages under a special branch called `gh-pages`. (dmX should be configured to be deployed under this branch)

This works as follows:

1. `static.yml`: This will be used to deploy a stable version of dmX to GitHub Pages.
2. `preview.yml`: Workflow to deploy dmX versions from PR's. That means that when opening, closing, etc, a PR, will be created a GitHub Page with that version in order to visualize the changes.
3. `development.yml`: Workflow that would work with a hypothetic `beta` branch to deploy early/testing versions of dmX.

These workflows can also be used for #15, where some testing should run on merges/pr's. 
ENDRELEASENOTES
