### PR TITLE
Execute drawAll function only once

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -337,9 +337,6 @@ document
     }
     start();
     hideInputModal();
-    setTimeout(() => {
-      drawAll();
-      toggle.init(infoBoxes, drawAll);
-    }, 500);
     window.scroll((canvas.width - window.innerWidth) / 2, 0);
+    toggle.init(infoBoxes, drawAll);
   });


### PR DESCRIPTION
BEGINRELEASENOTES
- After taking a closer look at `main.js`, I've noticed that when an event is visualized, `drawAll` function runs twice without an apparent reason: once in the event listener, and a second time inside `setTimeOut` function. When `start` is called, it calls `drawAll` already. So I think that we can remove this.
- The removal of `setTimeOut` will give a cleaner and faster experience when initially loading an event.

ENDRELEASENOTES
