### PR TITLE
Redirect from key4hep.github.io/dmx to key4hep.github.io/dmx/main

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+    <title>Redirecting to main branch</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=./main/index.html">
+    <link rel="canonical" href="https://key4hep.github.io/dmx/main/">
+</head>
+
+</html>


### PR DESCRIPTION
BEGINRELEASENOTES
- After #16 was merged, the original https://key4hep.github.io/dmx/ link is broken. So to fix this, as discussed in #14, we need to create an `index.html` file in the root directory under `gh-pages` branch that redirects to https://key4hep.github.io/dmx/main/.  

ENDRELEASENOTES
