### PR TITLE
Configure previews with access tokens and check out to fork

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -8,25 +8,37 @@ on:
             - synchronize
             - closed
 
-permissions:
-    contents: write
-    pull-requests: write
 jobs:
     deploy-preview:
+        environment: github-pages
         runs-on: ubuntu-latest
+        permissions:
+            pull-requests: write
         steps:
-            - uses: actions/checkout@v3
-            - uses: rossjrw/pr-preview-action@v1
+            - name: Checkout PR
+              uses: actions/checkout@v3
+              with:
+                  ref: ${{ github.event.pull_request.head.sha }}
+
+            - name: Deploy to GH-Pages
+              uses: rossjrw/pr-preview-action@v1
+              id: preview_step
               if: contains(['opened', 'reopened', 'synchronize'], ${{ github.event.action }})
               with:
                   source-dir: .
                   preview-branch: gh-pages
                   umbrella-dir: pr-preview
+                  deploy-repository: "key4hep/dmx"
+                  token: ${{ secrets.PR_TOKEN }}
                   action: auto
-            - uses: rossjrw/pr-preview-action@v1
+
+            - name: Remove preview
+              uses: rossjrw/pr-preview-action@v1
               if: github.event.action == 'closed' && !github.event.pull_request.merged
               with:
                   source-dir: .
                   preview-branch: gh-pages
                   umbrella-dir: pr-preview
+                  deploy-repository: "key4hep/dmx"
+                  token: ${{ secrets.PR_TOKEN }}
                   action: remove

--- a/index.html
+++ b/index.html
@@ -16,9 +16,9 @@
   <div id="input-modal" class="modal-background">
     <div class="modal-content">
 
-      <p>Welcome to <span id="logo">
+      <p>¡Welcome to <span id="logo">
           <span id="logo-d">d</span><span id="logo-m">m</span><span id="logo-x">X</span>
-        </span></p>
+        </span>!</p>
 
       <div id="input-message">
       </div>


### PR DESCRIPTION
BEGINRELEASENOTES
- Previews are configured to use access tokens to push PRs changes from a fork to the main repo and deploy to GitHub pages.

ENDRELEASENOTES

- So in PR #18 there is a problem with [previews](https://github.com/key4hep/dmx/pull/18#issuecomment-2126469317). When deploying, instead of showing the changes from the PR, it showed the same original repo as a preview. I suspected this, because in the `preview.yml`, the action never checked out to the PR, instead, it was to the same repo. However, I got confused when replicating, and thought It worked. After taking a closer look at my examples, I noticed that they never worked. This [preview](https://javascriptmadness.github.io/home/pr-preview/pr-8/) was supposed to show the [changes](https://github.com/JavascriptMadness/home/pull/8/files), but instead showed the same repo again. 
- I did some research and found a repository that uses [pr-preview-action](https://github.com/rossjrw/pr-preview-action) for their [previews](https://github.com/pokeclicker/pokeclicker/blob/develop/.github/workflows/deploy-pr.yml). With this, I got an idea on how to fix previews.
- To deploy previews, we need to:
    1. Checkout to the user's PR to show their changes.
    2. Push this to the original repo.
 
To do that we need: a fine-grained access token, that allows us to have **write** access to `key4hep/dmx` (more info at [docs](https://docs.github.com/en/rest/authentication/permissions-required-for-fine-grained-personal-access-tokens?apiVersion=2022-11-28) and generate like [this](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens#creating-a-fine-grained-personal-access-token)) and save this as a secret in the repo.
@tmadlener or @kjvbrt should generate the token and add it as a secret inside an environment called `github-pages` (This one I think was already automatically generated). The token should be called `PR_TOKEN`. This setting is available at Settings > Environments > github-pages > Add environment secret.

My working example has the main [website](https://javascriptmadness.github.io/home/main/) and a [preview](https://github.com/JavascriptMadness/home/pull/10) using this same action [file](https://github.com/JavascriptMadness/home/blob/main/.github/workflows/preview.yml).