### PR TITLE
Make test required to run successfully before deploying previews

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -9,7 +9,13 @@ on:
             - closed
 
 jobs:
+    test:
+        uses: key4hep/dmx/.github/workflows/test-previews.yml@main
+        with:
+            repository: ${{ github.event.pull_request.head.sha }}
+
     deploy-preview:
+        needs: test
         environment: github-pages
         runs-on: ubuntu-latest
         permissions:

--- a/.github/workflows/test-previews.yml
+++ b/.github/workflows/test-previews.yml
@@ -1,0 +1,26 @@
+name: Test previews
+on:
+    workflow_call:
+        inputs:
+            repository:
+                required: true
+                type: string
+
+jobs:
+    test:
+        environment: github-pages
+        runs-on: ubuntu-latest
+        steps:
+            - name: Checkout PR
+              uses: actions/checkout@v3
+              with:
+                  ref: ${{ inputs.repository }}
+            - name: Use Node.js
+              uses: actions/setup-node@v4
+              with:
+                  node-version: "20.x"
+                  cache: "npm"
+            - name: Install dependencies
+              run: npm install
+            - name: Run tests
+              run: npm test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,7 +1,7 @@
 name: Build and test
 on:
     push:
-        branches: [main]
+        branches: [main, release]
     pull_request:
         types: [opened, reopened, synchronize]
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,8 +2,6 @@ name: Build and test
 on:
     push:
         branches: [main, release]
-    pull_request:
-        types: [opened, reopened, synchronize]
 
 jobs:
     test:


### PR DESCRIPTION
BEGINRELEASENOTES
- Previews used to deploy without caring if the test suite ran successfully or not.
- From now on, exists a workflow file called `test-previews.yml` that would test only previews. If completed successfully, then previews will deploy. This will save time and resources.

ENDRELEASENOTES
As proposed by @kjvbrt, these changes will improve the overall deployment process. 
As usual, I've tested this on my "testing" [repository](https://github.com/JavascriptMadness/home/pulls). So basically, when opening a pull request, the `preview` workflow will be called. However, it then calls to `Test previews` which will checkout to the fork (PR) and test _that code_. Then if completed successfully, continues with normal deployment for previews. In theory, this won't run until merged, because the `test-previews` workflow should be in the repo, but currently isn't.  